### PR TITLE
Fix to work with cyrillic letters

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -168,7 +168,9 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 					}
 				}
 
-				$nLen = strlen($aMessage['BINARY_NOTIFICATION']);
+
+				$nLen = mb_strlen($aMessage['BINARY_NOTIFICATION'], '8bit');
+
 				$this->_log("STATUS: Sending message ID {$k} {$sCustomIdentifier} (" . ($nErrors + 1) . "/{$this->_nSendRetryTimes}): {$nLen} bytes.");
 
 				$aErrorMessage = null;
@@ -262,8 +264,8 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 	 */
 	protected function _getBinaryNotification($sDeviceToken, $sPayload, $nMessageID = 0, $nExpire = 604800)
 	{
-		$nTokenLength = strlen($sDeviceToken);
-		$nPayloadLength = strlen($sPayload);
+		$nTokenLength = mb_strlen($sDeviceToken, '8bit');
+		$nPayloadLength = mb_strlen($sPayload, '8bit');
 
 		$sRet  = pack('CNNnH*', self::COMMAND_PUSH, $nMessageID, $nExpire > 0 ? time() + $nExpire : 0, self::DEVICE_BINARY_SIZE, $sDeviceToken);
 		$sRet .= pack('n', $nPayloadLength);


### PR DESCRIPTION
I had problem on one server with messages in push, when one symbol is more than one byte. There was error xxx bytes instead of yyy bytes. It was fixed with this patch.

It is very strange, I think on another server ApnsPHP was working without patches. Can it be because of default server encoding?

I'm obj-c developer, not good in php, so I'm not very sure, that my fix is good for all cases, but I think, that mb_strlen with '8bit' is better to right counting of length in bytes. Isn't it?
