### PR TITLE
Allows messages with empty "aps" property.

### DIFF
--- a/ApnsPHP/Message.php
+++ b/ApnsPHP/Message.php
@@ -339,21 +339,24 @@ class ApnsPHP_Message
 	 */
 	protected function _getPayload()
 	{
-		$aPayload[self::APPLE_RESERVED_NAMESPACE] = array();
-
+		$aPayload = array();
+		
+		$aAppleReserved = array();
 		if (isset($this->_sText)) {
-			$aPayload[self::APPLE_RESERVED_NAMESPACE]['alert'] = (string)$this->_sText;
+			$aAppleReserved['alert'] = (string)$this->_sText;
 		}
 		if (isset($this->_nBadge) && $this->_nBadge >= 0) {
-			$aPayload[self::APPLE_RESERVED_NAMESPACE]['badge'] = (int)$this->_nBadge;
+			$aAppleReserved['badge'] = (int)$this->_nBadge;
 		}
 		if (isset($this->_sSound)) {
-			$aPayload[self::APPLE_RESERVED_NAMESPACE]['sound'] = (string)$this->_sSound;
+			$aAppleReserved['sound'] = (string)$this->_sSound;
 		}
 		if (isset($this->_bContentAvailable)) {
-			$aPayload[self::APPLE_RESERVED_NAMESPACE]['content-available'] = (int)$this->_bContentAvailable;
+			$aAppleReserved['content-available'] = (int)$this->_bContentAvailable;
 		}
-
+		if (count($aAppleReserved))
+			$aPayload[self::APPLE_RESERVED_NAMESPACE] = $aAppleReserved;
+		
 		if (is_array($this->_aCustomProperties)) {
 			foreach($this->_aCustomProperties as $sPropertyName => $mPropertyValue) {
 				$aPayload[$sPropertyName] = $mPropertyValue;
@@ -380,11 +383,10 @@ class ApnsPHP_Message
 				$sJSON);
 		}
 
-		$sJSONPayload = str_replace(
-			'"' . self::APPLE_RESERVED_NAMESPACE . '":[]',
-			'"' . self::APPLE_RESERVED_NAMESPACE . '":{}',
-			$sJSON
-		);
+		if ($sJSON === '[]')
+			$sJSONPayload = '{}';
+		else
+			$sJSONPayload = $sJSON;
 		$nJSONPayloadLen = strlen($sJSONPayload);
 
 		if ($nJSONPayloadLen > self::PAYLOAD_MAXIMUM_SIZE) {

--- a/ApnsPHP/Message/Custom.php
+++ b/ApnsPHP/Message/Custom.php
@@ -28,6 +28,8 @@
  */
 class ApnsPHP_Message_Custom extends ApnsPHP_Message
 {
+	const APPLE_ALERT_PROPERTY = 'alert'; /**< @type string The alert child property. */
+	
 	protected $_sActionLocKey; /**< @type string The "View" button title. */
 	protected $_sLocKey; /**< @type string A key to an alert-message string in a Localizable.strings file */
 	protected $_aLocArgs; /**< @type array Variable string values to appear in place of the format specifiers in loc-key. */
@@ -142,28 +144,26 @@ class ApnsPHP_Message_Custom extends ApnsPHP_Message
 	{
 		$aPayload = parent::_getPayload();
 
-		$aPayload['aps']['alert'] = array();
-
+		$aAlert = array();
+	
 		if (isset($this->_sText) && !isset($this->_sLocKey)) {
-			$aPayload['aps']['alert']['body'] = (string)$this->_sText;
+			$aAlert['body'] = (string)$this->_sText;
 		}
-
 		if (isset($this->_sActionLocKey)) {
-			$aPayload['aps']['alert']['action-loc-key'] = $this->_sActionLocKey == '' ?
+			$aAlert['action-loc-key'] = $this->_sActionLocKey == '' ?
 				null : (string)$this->_sActionLocKey;
 		}
-
 		if (isset($this->_sLocKey)) {
-			$aPayload['aps']['alert']['loc-key'] = (string)$this->_sLocKey;
+			$aAlert['loc-key'] = (string)$this->_sLocKey;
 		}
-
 		if (isset($this->_aLocArgs)) {
-			$aPayload['aps']['alert']['loc-args'] = $this->_aLocArgs;
+			$aAlert['loc-args'] = $this->_aLocArgs;
 		}
-
 		if (isset($this->_sLaunchImage)) {
-			$aPayload['aps']['alert']['launch-image'] = (string)$this->_sLaunchImage;
+			$aAlert['launch-image'] = (string)$this->_sLaunchImage;
 		}
+		if (count($aAlert))
+			$aPayload[parent::APPLE_RESERVED_NAMESPACE][self::APPLE_ALERT_PROPERTY] = $aAlert;
 
 		return $aPayload;
 	}


### PR DESCRIPTION
While playing around with MDM service and ApnsPHP, I notice that mdmd daemon on the supervised device is not happy with empty "aps" property.
BTW, the APNS documentation says that the "aps" is reserved but not mandatory: in fact, MDM service doesn't need it at all. And omitting the empty dictionary can save few bytes which can become big when you manage thousands of devices.
So I propose this patch to allow messages with no "aps" property.

Regards.
