### PR TITLE
Solving an issue with indefinite hanging on stream. #45

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -292,6 +292,9 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 	 */
 	protected function _readErrorMessage()
 	{
+		$stream_meta_data=stream_get_meta_data($this->_hSocket);
+		if ($stream_meta_data['unread_bytes']<=0) { return; }
+		
 		$sErrorResponse = @fread($this->_hSocket, self::ERROR_RESPONSE_SIZE);
 		if ($sErrorResponse === false || strlen($sErrorResponse) != self::ERROR_RESPONSE_SIZE) {
 			return;


### PR DESCRIPTION
The main concerns are: whether or not ‘unread_bytes’ is actually populated without an fread(), and also whether or not a loop is needed with a timeout to check fread() multiple times (with an assigned timeout) or to check ‘unread_bytes’ several times within X seconds before aborting.
