### PR TITLE
Fix ApnsPHP_Push to not send a pcnt_signal_dispatch if is not in serverMode

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -39,6 +39,8 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 
 	const STATUS_CODE_INTERNAL_ERROR = 999; /**< @type integer Status code for internal error (not Apple). */
 
+	protected $_bServerMode = false; /** @type boolean Server mode sends a pcntl_signal_dispatch on send method. Used by ApnsPHP_Push_Server */
+
 	protected $_aErrorResponseMessages = array(
 		0   => 'No errors encountered',
 		1   => 'Processing error',
@@ -138,7 +140,7 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 
 			$bError = false;
 			foreach($this->_aMessageQueue as $k => &$aMessage) {
-				if (function_exists('pcntl_signal_dispatch')) {
+				if ($this->_bServerMode && function_exists('pcntl_signal_dispatch')) {
 					pcntl_signal_dispatch();
 				}
 

--- a/ApnsPHP/Push/Server.php
+++ b/ApnsPHP/Push/Server.php
@@ -60,6 +60,7 @@ class ApnsPHP_Push_Server extends ApnsPHP_Push
 	{
 		parent::__construct($nEnvironment, $sProviderCertificateFile);
 
+		$this->_bServerMode = true;
 		$this->_nParentPid = posix_getpid();
 		$this->_hShm = shm_attach(mt_rand(), self::SHM_SIZE);
 		if ($this->_hShm === false) {


### PR DESCRIPTION
If running standalone ApnsPHP_Push in a custom cli script that uses pcntl signals, sending APNS notifications will affect the proper function of it.