### PR TITLE
strlen replaced by preg_match_all

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -168,7 +168,7 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 					}
 				}
 
-				$nLen = strlen($aMessage['BINARY_NOTIFICATION']);
+				$nLen = preg_match_all( '(.)su', $aMessage['BINARY_NOTIFICATION'], $matches );
 				$this->_log("STATUS: Sending message ID {$k} {$sCustomIdentifier} (" . ($nErrors + 1) . "/{$this->_nSendRetryTimes}): {$nLen} bytes.");
 
 				$aErrorMessage = null;


### PR DESCRIPTION
There is a known bug in PHP (ID = 68644). Text copied from it:

If set in php.ini:
mbstring.func_overload=2
mbstring.internal_encoding="UTF-8"
or in .htaccess
php_value mbstring.func_overload 2
php_value mbstring.internal_encoding UTF-8

And set enable extension mbstring and opcache.

And after all run the script, the result will be the first implementation of the correct result, but subsequent executions F5 will give an incorrect result.
Strlen not overload by mb_strlen.
Other function such as substr and strtolower and etc work perfectly.
If you disable opcahe problem disappears.