### PR TITLE
Skip autoloading instead of throwing exceptions

### DIFF
--- a/ApnsPHP/Autoload.php
+++ b/ApnsPHP/Autoload.php
@@ -27,18 +27,16 @@
  * @see http://php.net/spl_autoload_register
  *
  * @param  $sClassName @type string The class name.
- * @throws Exception if class name is empty, the current path is empty or class
- *         file does not exists or file was loaded but class name was not found.
  */
 function ApnsPHP_Autoload($sClassName)
 {
 	if (empty($sClassName)) {
-		throw new Exception('Class name is empty');
+		return;
 	}
 
 	$sPath = dirname(dirname(__FILE__));
 	if (empty($sPath)) {
-		throw new Exception('Current path is empty');
+		return;
 	}
 
 	$sFile = sprintf('%s%s%s.php',


### PR DESCRIPTION
My use case is starting with Twig, somehow when checking for `__toString` method the autoload mechanism is triggered even on simple values, and then checking for "0" raises Exception - as it is `empty()`'ish.
I think that autoload should not throw exceptions if class is simply not found, changing it to simple returns should prevent surprises for devs.